### PR TITLE
Util/lowlevel.h: Include ACLE intrinsics header

### DIFF
--- a/Drivers/Util/lowlevel.h
+++ b/Drivers/Util/lowlevel.h
@@ -27,6 +27,7 @@
  * Provides low level macros such as __disable_irq()
  */
 #include <arm_compat.h>
+#include <arm_acle.h>
 
 #define __disable_bothirqs() __asm( "CPSID if")
 


### PR DESCRIPTION
`__arm_mcr` and `__arm_mrc` are declared in `arm_acle.h`, which was not explicitly included in `lowlevel.h`.  This was causing compilation failures where symbols `__arm_mcr` and `__arm_mrc` could not be found.

Error observed on the lab machines, which are running a slightly older version of the Arm compiler.  I suspect on newer compilers the header is included transitively somehow, hence this going unnoticed before now.